### PR TITLE
Android: display timestamps

### DIFF
--- a/android/app/src/main/java/com/fra/plutomierz/ui/ChatHistory.kt
+++ b/android/app/src/main/java/com/fra/plutomierz/ui/ChatHistory.kt
@@ -9,12 +9,13 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 
 @Composable
 fun ChatHistory(
-    chatHistory: List<Pair<String, String>>,
+    chatHistory: List<Triple<String, String, String>>, // Updated to Triple to include timestamp
     modifier: Modifier = Modifier
 ) {
     val listState = rememberLazyListState()
@@ -25,7 +26,7 @@ fun ChatHistory(
             .fillMaxSize()
             .padding(4.dp)
     ) {
-        items(chatHistory) { (user, text) ->
+        items(chatHistory) { (user, text, timestamp) ->
             Card(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -37,11 +38,23 @@ fun ChatHistory(
                         .fillMaxWidth()
                         .padding(8.dp)
                 ) {
-                    Text(
-                        text = user,
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.primary
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.fillMaxWidth()
                     )
+                    {
+                        Text(
+                            text = user,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                        Text(
+                            text = timestamp,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+                            modifier = Modifier.padding(start = 8.dp)
+                        )
+                    }
                     Spacer(modifier = Modifier.height(4.dp))
                     Text(
                         text = text,
@@ -51,5 +64,4 @@ fun ChatHistory(
             }
         }
     }
-
 }

--- a/android/app/src/main/java/com/fra/plutomierz/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/fra/plutomierz/ui/MainActivity.kt
@@ -49,6 +49,16 @@ class MainActivity : ComponentActivity() {
         }
     }
 
+    private fun parseMessage(msg: JSONObject): Triple<String, String, String> {
+        return Triple(
+            msg.getString("username"),
+            msg.getString("text"),
+            "${msg.getString("timestamp").substring(0, 10)} ${
+                msg.getString("timestamp").substring(11, 19)
+            }"
+        )
+    }
+
     @OptIn(ExperimentalMaterial3Api::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -56,7 +66,11 @@ class MainActivity : ComponentActivity() {
         setContent {
             val scope = rememberCoroutineScope()
             var plutaValue by remember { mutableDoubleStateOf(0.0) }
-            var chatHistory by remember { mutableStateOf(listOf<Pair<String, String>>()) }
+            var chatHistory: List<Triple<String, String, String>> by remember {
+                mutableStateOf(
+                    listOf<Triple<String, String, String>>()
+                )
+            }
 
             webSocketHandler = WebSocketHandler(
                 onMessageReceived = { text ->
@@ -64,10 +78,12 @@ class MainActivity : ComponentActivity() {
                     when (json.getString("type")) {
                         "history" -> {
                             val messages = json.getJSONArray("messages")
-                            val history = mutableListOf<Pair<String, String>>()
+                            val history = mutableListOf<Triple<String, String, String>>()
                             for (i in 0 until messages.length()) {
                                 val msg = messages.getJSONObject(i)
-                                history.add(Pair(msg.getString("username"), msg.getString("text")))
+                                history.add(
+                                    parseMessage(msg)
+                                )
                             }
                             chatHistory = history.reversed()
                         }
@@ -75,10 +91,7 @@ class MainActivity : ComponentActivity() {
                         "message" -> {
                             val msg = json.getJSONObject("message")
                             chatHistory = listOf(
-                                Pair(
-                                    msg.getString("username"),
-                                    msg.getString("text")
-                                )
+                                parseMessage(msg)
                             ) + chatHistory
                         }
 


### PR DESCRIPTION
This pull request introduces changes to the `ChatHistory` component to include timestamps for each message and refactors the message parsing logic in the `MainActivity` class. The most important changes include updating the data structure, modifying the UI to display timestamps, and adding a helper function to parse messages.

Changes to `ChatHistory` component:

* Updated the `chatHistory` parameter to use `Triple` instead of `Pair` to include timestamps.
* Modified the `items` call to destructure the `Triple` and include the `timestamp` in the UI.
* Added a `Row` composable to display the `user` and `timestamp` side by side.

Changes to `MainActivity` class:

* Added a `parseMessage` function to convert JSON messages into `Triple` with username, text, and formatted timestamp.
* Updated the `chatHistory` state and message handling logic to use `Triple` instead of `Pair`.

![image](https://github.com/user-attachments/assets/cfa01b76-91cd-4965-8b53-28994b00e0b3)

Resolves #28 