### PR TITLE
API: Fix invalid trimming logic in message validation

### DIFF
--- a/api/src/websocket/utils/validation.ts
+++ b/api/src/websocket/utils/validation.ts
@@ -1,5 +1,6 @@
 function validateAndFormatMessage(message: string): { valid: boolean, formattedMessage?: string, error?: string } {
-    const trimmedMessage = message.trim().replace(/\s+/g, ' ');
+    const cleanedMessage = message.replace(/[\u200B-\u200D\uFEFF]/g, '');
+    const trimmedMessage = cleanedMessage.trim().replace(/\s+/g, ' ');
 
     if (trimmedMessage.length === 0) {
         return {valid: false, error: 'Message cannot be empty'};

--- a/api/src/websocket/utils/validation.ts
+++ b/api/src/websocket/utils/validation.ts
@@ -1,5 +1,5 @@
 function validateAndFormatMessage(message: string): { valid: boolean, formattedMessage?: string, error?: string } {
-    const cleanedMessage = message.replace(/[\u200B-\u200D\uFEFF]/g, '');
+    const cleanedMessage = message.replace(/[\u0020\u00A0\u200B\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u202F\u205F\u3000\u200E\u200F]/g, ' ');
     const trimmedMessage = cleanedMessage.trim().replace(/\s+/g, ' ');
 
     if (trimmedMessage.length === 0) {
@@ -14,7 +14,8 @@ function validateAndFormatMessage(message: string): { valid: boolean, formattedM
 }
 
 function validateAndFormatNickname(nickname: string): { valid: boolean, formattedNickname?: string, error?: string } {
-    const trimmedNickname = nickname.trim().replace(/\s+/g, ' ');
+    const cleanedNickname = nickname.replace(/[\u0020\u00A0\u200B\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u202F\u205F\u3000\u200E\u200F]/g, ' ');
+    const trimmedNickname = cleanedNickname.trim().replace(/\s+/g, ' ');
 
     if (trimmedNickname.length === 0) {
         return {valid: false, error: 'Nickname cannot be empty'};
@@ -30,5 +31,3 @@ function validateAndFormatNickname(nickname: string): { valid: boolean, formatte
 
     return {valid: true, formattedNickname: trimmedNickname};
 }
-
-export {validateAndFormatMessage, validateAndFormatNickname};

--- a/api/src/websocket/utils/validation.ts
+++ b/api/src/websocket/utils/validation.ts
@@ -31,3 +31,5 @@ function validateAndFormatNickname(nickname: string): { valid: boolean, formatte
 
     return {valid: true, formattedNickname: trimmedNickname};
 }
+
+export {validateAndFormatMessage, validateAndFormatNickname};


### PR DESCRIPTION
Resolves #43

This pull request includes changes to the `api/src/websocket/utils/validation.ts` file to improve the cleaning and trimming of messages and nicknames by removing a wider range of whitespace characters.

Improvements to message and nickname validation:

* [`validateAndFormatMessage`](diffhunk://#diff-f438c7eac38dfc8fdd6a9fd9d333ea36b27705d90dd7d88cc9eeb05c862a0758L2-R3): Updated to replace a broader set of whitespace characters before trimming and formatting the message.
* [`validateAndFormatNickname`](diffhunk://#diff-f438c7eac38dfc8fdd6a9fd9d333ea36b27705d90dd7d88cc9eeb05c862a0758L16-R18): Updated to replace a broader set of whitespace characters before trimming and formatting the nickname.