### PR TITLE
Android: Allow user to change username only one time

### DIFF
--- a/android/app/src/main/java/com/fra/plutomierz/data/PreferencesHelper.kt
+++ b/android/app/src/main/java/com/fra/plutomierz/data/PreferencesHelper.kt
@@ -6,6 +6,7 @@ import android.content.SharedPreferences
 object PreferencesHelper {
     private const val PREFS_NAME = "chat_prefs"
     private const val KEY_USERNAME = "username"
+    private const val KEY_USERNAME_CHANGED = "username_changed"
 
     private fun getPreferences(context: Context): SharedPreferences {
         return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -17,7 +18,18 @@ object PreferencesHelper {
         editor.apply()
     }
 
+    fun editUsername(context: Context, username: String) {
+        saveUsername(context, username)
+        if (getUsername(context) != username) {
+            getPreferences(context).edit().putBoolean(KEY_USERNAME_CHANGED, true).apply()
+        }
+    }
+
     fun getUsername(context: Context): String? {
         return getPreferences(context).getString(KEY_USERNAME, null)
+    }
+
+    fun hadUsernameChanged(context: Context): Boolean {
+        return getPreferences(context).getBoolean(KEY_USERNAME_CHANGED, false)
     }
 }

--- a/android/app/src/main/java/com/fra/plutomierz/ui/SettingsActivity.kt
+++ b/android/app/src/main/java/com/fra/plutomierz/ui/SettingsActivity.kt
@@ -1,7 +1,7 @@
 package com.fra.plutomierz.ui
 
-import android.content.Context
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.Column
@@ -16,6 +16,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.fra.plutomierz.data.PreferencesHelper
+import com.fra.plutomierz.data.PreferencesHelper.getUsername
+import com.fra.plutomierz.data.PreferencesHelper.hadUsernameChanged
 import com.fra.plutomierz.ui.theme.PlutomierzTheme
 import com.fra.plutomierz.util.NotificationUtils
 import com.fra.plutomierz.utils.getRandomMotivationalText
@@ -36,9 +38,8 @@ class SettingsActivity : ComponentActivity() {
 @Composable
 fun SettingsScreen(onBackPressed: () -> Unit) {
     val context = LocalContext.current
-    val sharedPreferences = context.getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
     var notificationsEnabled by remember { mutableStateOf(true) }
-    var nickname by remember { mutableStateOf(PreferencesHelper.getUsername(context) ?: "") }
+    var username by remember { mutableStateOf(getUsername(context) ?: "") }
     var tapCount by remember { mutableIntStateOf(0) }
     var showEasterEgg by remember { mutableStateOf(false) }
 
@@ -78,18 +79,41 @@ fun SettingsScreen(onBackPressed: () -> Unit) {
                 }
             )
             Spacer(modifier = Modifier.padding(8.dp))
-            Text("Zmień nazwę Pluty")
+            Text("Zmień nazwę Pluty (tylko raz)")
             TextField(
-                value = nickname,
-                onValueChange = { nickname = it },
+                value = username,
+                onValueChange = { username = it },
                 label = { Text("Pluta") },
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxWidth(),
+                enabled = !hadUsernameChanged(context)
             )
             Button(
                 onClick = {
-                    sharedPreferences.edit().putString("nickname", nickname).apply()
+                    if (username.isNotEmpty()) {
+                        if (!hadUsernameChanged(context)) {
+                            PreferencesHelper.editUsername(context, username)
+                            Toast.makeText(
+                                context,
+                                "Nazwa użytkownika została zmieniona",
+                                Toast.LENGTH_SHORT
+                            ).show()
+                        } else {
+                            Toast.makeText(
+                                context,
+                                "Nazwa użytkownika może zostać zmieniona tylko raz",
+                                Toast.LENGTH_SHORT
+                            ).show()
+                        }
+                    } else {
+                        Toast.makeText(
+                            context,
+                            "Nazwa użytkownika nie została jeszcze ustawiona",
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    }
                 },
-                modifier = Modifier.padding(top = 8.dp)
+                modifier = Modifier.padding(top = 8.dp),
+                enabled = username.isNotEmpty() && !hadUsernameChanged(context)
             ) {
                 Text("Zapisz")
             }

--- a/android/app/src/main/java/com/fra/plutomierz/ui/components/ChatInput.kt
+++ b/android/app/src/main/java/com/fra/plutomierz/ui/components/ChatInput.kt
@@ -16,7 +16,7 @@ fun ChatInput(
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
-    var username by remember { mutableStateOf(PreferencesHelper.getUsername(context) ?: "") }
+    var username = PreferencesHelper.getUsername(context) ?: ""
     var message by remember { mutableStateOf("") }
     var isUsernameSet by remember { mutableStateOf(username.isNotEmpty()) }
     var usernameError by remember { mutableStateOf(false) }


### PR DESCRIPTION
This pull request introduces several enhancements to the `PreferencesHelper` class and updates the `SettingsActivity` and `ChatInput` components to improve username management. The most important changes include adding a new method to edit the username, ensuring the username can only be changed once, and updating the UI to reflect these changes.

Enhancements to username management:

* [`android/app/src/main/java/com/fra/plutomierz/data/PreferencesHelper.kt`](diffhunk://#diff-d66f05c03914b8484a12c46930ec7da78794bd6d649f535707ecb460b1661227R9): Added `KEY_USERNAME_CHANGED` constant and methods `editUsername` and `hadUsernameChanged` to manage username changes and track if the username has been changed. [[1]](diffhunk://#diff-d66f05c03914b8484a12c46930ec7da78794bd6d649f535707ecb460b1661227R9) [[2]](diffhunk://#diff-d66f05c03914b8484a12c46930ec7da78794bd6d649f535707ecb460b1661227R21-R34)

UI updates to reflect username management:

* [`android/app/src/main/java/com/fra/plutomierz/ui/SettingsActivity.kt`](diffhunk://#diff-6540ce81d69010a5bfb8cfbb491a1e7f9e57ba1e93bb768b2808d296afe21db7L3-R4): Updated the `SettingsScreen` to use `username` instead of `nickname`, added logic to prevent changing the username more than once, and displayed appropriate messages using `Toast`. [[1]](diffhunk://#diff-6540ce81d69010a5bfb8cfbb491a1e7f9e57ba1e93bb768b2808d296afe21db7L3-R4) [[2]](diffhunk://#diff-6540ce81d69010a5bfb8cfbb491a1e7f9e57ba1e93bb768b2808d296afe21db7R19-R20) [[3]](diffhunk://#diff-6540ce81d69010a5bfb8cfbb491a1e7f9e57ba1e93bb768b2808d296afe21db7L39-R42) [[4]](diffhunk://#diff-6540ce81d69010a5bfb8cfbb491a1e7f9e57ba1e93bb768b2808d296afe21db7L81-R116)
* [`android/app/src/main/java/com/fra/plutomierz/ui/components/ChatInput.kt`](diffhunk://#diff-68c1820c8c4dea963428871d7e9aed896ac5ab4e82807fed3a78f4f6c7d57587L19-R19): Simplified the username initialization by removing the `remember` state for `username`.