### PR TITLE
Web: Inappropriate text on timer

### DIFF
--- a/web/src/components/plutaTimer/PlutaTimer.jsx
+++ b/web/src/components/plutaTimer/PlutaTimer.jsx
@@ -22,9 +22,9 @@ function PlutaTimer() {
     useEffect(() => {
         const countdown = ((11 - hour) * 60) + 45 - minute;
 
-        if (day === 6 || day === 0) {
+        if (day === 6 || day === 0 || (day === 5 && countdown <= -20)) {
             setStatusSkrotu("Weekend. Do zobaczenia w poniedziałek na skrócie!");
-        } else if (countdown <= 660 && countdown > 0) {
+        } else if (countdown <= 705 && countdown > 0) {
             setStatusSkrotu("Panowie, za " + countdown + " minut Skrót Pluty!");
         } else if (countdown <= 0 && countdown > -20) {
             setStatusSkrotu("WSZYSCY NA SKRÓT PLUTY!!!");


### PR DESCRIPTION
The text on timer was not displaying properly in two cases:
- on workdays, from midnight until around 1 AM the text was missing
- on friday after skrót Pluty timer displayed text inviting for next day's skrót