### PR TITLE
Api: Bugfix to weekend midnight pluta, pluta value adjustments

### DIFF
--- a/api/src/plutaValue/calcFactorFunctions/break.ts
+++ b/api/src/plutaValue/calcFactorFunctions/break.ts
@@ -8,16 +8,16 @@ const regularBreaks = [
     [1250, 1300], [1345, 1355], [1440, 1450], [1535, 1545]
 ];
 
-export default function calcBreakFactor(time: number): number {
+export default function calcBreakFactor(time: number, day: number): number {
     const longBreakFactorial = 1;
     const almostLongBreakFactorial = 0.5;
     const shortBreakFactorial = 0.25;
 
     if (LONG_BREAK_START <= time && time <= LONG_BREAK_END) {
-        return longBreakFactorial;
+        return day >= 5 ? longBreakFactorial : (longBreakFactorial/2);
     } else if ((ALMOST_LONG_BREAK_START <= time && time < LONG_BREAK_START) || (LONG_BREAK_END < time && time <= ALMOST_LONG_BREAK_END)) {
-        return almostLongBreakFactorial;
-    } else {
+        return day >= 5 ? almostLongBreakFactorial : (almostLongBreakFactorial/2);
+    } else if (day >= 5) {
         for (const [start, end] of regularBreaks) {
             if (start <= time && time <= end) {
                 return shortBreakFactorial;

--- a/api/src/plutaValue/calcFactorFunctions/weekendNight.ts
+++ b/api/src/plutaValue/calcFactorFunctions/weekendNight.ts
@@ -1,18 +1,29 @@
 import sinusoidalBonusBetweenHours from "./sinusoidalBonusBetweenHours";
 
 export default function weekendNight(time: number, day: number): number {
-    if( 5 <= day && day <= 7 ) {
-        if ( 1800 <= time && time <= 2100 ){
-            return sinusoidalBonusBetweenHours(time, 1800, 2400, 1)
-        }
-        else if ( day != 7 ){
-            if ( 200 <= time && time <= 400){
-                return sinusoidalBonusBetweenHours(time, 0, 400, 1)
+    if ( 5 <= day && day <= 7 ) {
+
+        if (1800 <= time && time <= 2100) {
+            if (day == 5 || day == 6) {
+                return sinusoidalBonusBetweenHours(time, 1800, 2400, 1)
             }
-            else if ( time >= 2100 || time <= 200){
+
+        } else if (2100 <= time && time <= 2400) {
+            if (day == 5 || day == 6) {
                 return 1
+            }
+
+        } else if (0 <= time && time <= 200) {
+            if (day == 6 || day == 7) {
+                return 1
+            }
+
+        } else if (200 <= time && time <= 400) {
+            if (day == 6 || day == 7) {
+                return sinusoidalBonusBetweenHours(time, 0, 400, 1)
             }
         }
     }
+
     return 0
 }

--- a/api/src/plutaValue/getPlutaValue.ts
+++ b/api/src/plutaValue/getPlutaValue.ts
@@ -152,7 +152,7 @@ const getPlutaValue = async (latitude: number, longitude: number) => {
     bonuses["plutaTime"] = plutaTimeFactorWithoutPlutaConcentration * multipliers["plutaTime"]
 
     // base pluta to make overall plutas higher
-    const basePluta = 17.5;
+    const basePluta = 15;
 
     let maxPluta = 0
     for (const multiplier in multipliers) {

--- a/api/src/plutaValue/getPlutaValue.ts
+++ b/api/src/plutaValue/getPlutaValue.ts
@@ -68,7 +68,7 @@ const getPlutaValue = async (latitude: number, longitude: number) => {
 
     // breaks
     multipliers["break"] = 20
-    bonuses["break"] = calcBreakFactor(time) * multipliers["break"]
+    bonuses["break"] = calcBreakFactor(time, day) * multipliers["break"]
 
     // days
     multipliers["day"] = 8


### PR DESCRIPTION
This pull request includes changes to the `api/src/plutaValue` directory to enhance the calculation of break factors and weekend night bonuses, and to adjust the base Pluta value. The most important changes include adding a `day` parameter to the `calcBreakFactor` function, updating the `weekendNight` function logic, and modifying the `getPlutaValue` function to incorporate these updates.

Enhancements to break factor calculations:

* [`api/src/plutaValue/calcFactorFunctions/break.ts`](diffhunk://#diff-d8654953ad2dc443d90a8c20bb51c189d8613442bd2f9358ed2c74b8c5d6f3eeL11-R20): Added a `day` parameter to the `calcBreakFactor` function and adjusted the return values based on the day of the week.

Updates to weekend night bonus logic:

* [`api/src/plutaValue/calcFactorFunctions/weekendNight.ts`](diffhunk://#diff-8f317c18a52d7b418329e6a751f8283af730feda3f604d272e52ad2d2cf7f944R5-R27): Refined the logic in the `weekendNight` function to provide different bonuses based on the time and day of the week.

Adjustments in Pluta value calculations:

* [`api/src/plutaValue/getPlutaValue.ts`](diffhunk://#diff-f6e45e9b832feab2e4649404919c110d1ab6688b87e293c82fe807f90d497888L71-R71): Updated the call to `calcBreakFactor` to include the new `day` parameter.
* [`api/src/plutaValue/getPlutaValue.ts`](diffhunk://#diff-f6e45e9b832feab2e4649404919c110d1ab6688b87e293c82fe807f90d497888L155-R155): Adjusted the `basePluta` value from 17.5 to 15.